### PR TITLE
Fixed comment markers in TOC file

### DIFF
--- a/Immersion/Immersion.toc
+++ b/Immersion/Immersion.toc
@@ -4,18 +4,18 @@
 ## Version: 0.0.8
 ## SavedVariables: ImmersionSetup
 
--- Libs
+# Libs
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
 Libs\AceGUI-3.0\AceGUI-3.0.xml
 Libs\AceConfig-3.0\AceConfig-3.0.xml
 Libs\Animation.lua
 
--- Extra stuff & config
+# Extra stuff & config
 Extras.lua
 Config.lua
 
--- Mixins
+# Mixins
 Mixins\Scaler.lua
 Mixins\Titles.lua
 Mixins\Text.lua
@@ -23,9 +23,9 @@ Mixins\Model.lua
 Mixins\Button.lua
 Mixins\Elements.lua
 
--- Display layer
+# Display layer
 Frame.xml
 Frame.lua
 
--- Logic layer
+# Logic layer
 Logic.lua


### PR DESCRIPTION
Comments in the TOC file should just use a single `#` character as opposed to being Lua style (`--`).

This fixes some entirely harmless warning messages in the `FrameXML.log` file in the game's logging directory, which look like this without the fix applied:

```
2/16 12:41:18.147  Loading add-on Immersion
2/16 12:41:18.147  ** Loading table of contents Interface\AddOns\Immersion\Immersion.toc
2/16 12:41:18.147  Couldn't open Interface\AddOns\Immersion\-- Libs
2/16 12:41:18.147  Couldn't open Interface\AddOns\Immersion\-- Extra stuff & config
2/16 12:41:18.147  Couldn't open Interface\AddOns\Immersion\-- Mixins
2/16 12:41:18.147  Couldn't open Interface\AddOns\Immersion\-- Display layer
2/16 12:41:18.147  Couldn't open Interface\AddOns\Immersion\-- Logic layer
```