### PR TITLE
Fix spaced ellipses

### DIFF
--- a/Immersion/Mixins/Text.lua
+++ b/Immersion/Mixins/Text.lua
@@ -51,8 +51,9 @@ end
 function Text:AddString(str, strings, delays)
 	local length, delay, force = str:len(), 0
 	if length > MAX_UNTIL_SPLIT then
-		local new = str -- substitute natural breaks with newline.
-			:gsub('%.%s+', '.\n') -- sentence
+        local new = str -- substitute natural breaks with newline.
+            :gsub('%.%s%.%s%.', '...') --- fix spaced ellipses
+            :gsub('%.%s+', '.\n') -- sentence
 			:gsub('%.%.%.\n', '...\n...') -- ponder
 			:gsub('%!%s+', '!\n'):gsub('%?%s+', '?\n') -- question/exclamation.
 		--[[ If the string is unchanged, this will recurse infinitely, therefore


### PR DESCRIPTION
Occasionally, a quest writer will employ an ellipsis with spaces between each of the periods, causing the addon to parse each period as the end of a sentence.  This commit removes the spaces from such "spaced ellipses" as a first step.