### PR TITLE
Fixed progress bar with NPC friendship reputation to display correct progress

### DIFF
--- a/Interface.lua
+++ b/Interface.lua
@@ -319,7 +319,8 @@ function API:GetUnitName(...)
 end
 
 function API:GetFriendshipReputation(...)
-	return GetFriendshipReputation and GetFriendshipReputation(...) or 0
+	if GetFriendshipReputation then return GetFriendshipReputation(...) end
+	return 0
 end
 
 function API:GetPortraitAtlas()


### PR DESCRIPTION
I have noticed that friendship progress bar is broken and doesn't display correct progress. It's a simple fix but I'd like to mention that I have no experience it LUA at all so I'm not absolutely sure what causes this but I've noticed these 2 differences in the evaluation:

`/run print(GetFriendshipReputation())` gives me `2432 3245 42000 Ve'nari` ... and so on for Ve'nari NPC in The Maw.

`/run print(GetFriendshipReputation() or 0)` gives me just `2432` so everything besides faction ID is completely lost.

I guess type inference in LUA somehow assumes that the return type is just a single integer if there's explicit ` or 0`. Attaching screens of how it looks before and after the fix.

Without fix:
![without_fix](https://user-images.githubusercontent.com/1035583/100520949-ffbc7000-31a0-11eb-936e-186b5ce528e5.png)

With fix:
![with_fix](https://user-images.githubusercontent.com/1035583/100520951-01863380-31a1-11eb-8d31-c9aaabd6532d.png)
