### PR TITLE
Close TalkBox with left click.

### DIFF
--- a/Logic/Logic.lua
+++ b/Logic/Logic.lua
@@ -604,6 +604,8 @@ function TalkBox:OnLeftClick()
 		else
 			ImmersionFrame:ForceClose()
 		end
+	else
+		ImmersionFrame:ForceClose()
 	end
 end
 


### PR DESCRIPTION
Some NPC interactions cannot be ended by just clicking on the TalkBox. You have to click the "x" close button instead. It would be much more comfortable to also close the talk box with a mouse click; just like when you are closing it when accepting a quest. This simple addition to the code solved it for me.