### PR TITLE
Update Interface.lua

### DIFF
--- a/Interface.lua
+++ b/Interface.lua
@@ -2,7 +2,7 @@ local API = {}; ImmersionAPI = API;
 -- Version
 local IS_VANILLA = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC or nil;
 local IS_RETAIL  = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE or nil;
-local IS_CLASSIC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC or nil;
+local IS_CLASSIC = WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC or nil;
 
 function API:IsVanilla() return IS_VANILLA end
 function API:IsRetail()  return IS_RETAIL  end


### PR DESCRIPTION
Fix for the following error after today's patch

```
1x Immersion\Interface.lua:26: 'for' step must be a number
[string "@Immersion\Interface.lua"]:26: in function <Immersion\Interface.lua:24>
[string "=(tail call)"]: ?
[string "@Immersion\Mixins\Titles.lua"]:184: in function `?'
[string "@Immersion\Mixins\Titles.lua"]:106: in function <Immersion\Mixins\Titles.lua:104>

Locals:
lambda = <function> defined @Immersion\Interface.lua:32
step = nil
data = <table> {
}
(for index) = 1
(for limit) = 0
(for step) = nil
(*temporary) = 0
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "'for' step must be a number"
```