### PR TITLE
fix making sure immersion window closes after opening other window like shopping

### DIFF
--- a/Display/Onload.lua
+++ b/Display/Onload.lua
@@ -42,6 +42,7 @@ for _, event in pairs({
 --	'MERCHANT_SHOW', 	-- Force close gossip on merchant interaction.
 	'NAME_PLATE_UNIT_ADDED', 	-- For nameplate mode
 	'NAME_PLATE_UNIT_REMOVED', 	-- For nameplate mode
+	ImmersionAPI.IsRetail and 'PLAYER_INTERACTION_MANAGER_FRAME_HIDE', -- Makes sure it closes after interaction screen like flight master
 	ImmersionAPI.IsRetail and 'SUPER_TRACKING_CHANGED',
 }) do if event then
 		frame:RegisterEvent(event)

--- a/Display/Onload.lua
+++ b/Display/Onload.lua
@@ -42,7 +42,7 @@ for _, event in pairs({
 --	'MERCHANT_SHOW', 	-- Force close gossip on merchant interaction.
 	'NAME_PLATE_UNIT_ADDED', 	-- For nameplate mode
 	'NAME_PLATE_UNIT_REMOVED', 	-- For nameplate mode
-	ImmersionAPI.IsRetail and 'PLAYER_INTERACTION_MANAGER_FRAME_HIDE', -- Makes sure it closes after interaction screen like flight master
+	ImmersionAPI.IsWoW10 and 'PLAYER_INTERACTION_MANAGER_FRAME_HIDE', -- Makes sure it closes after interaction screen like flight master
 	ImmersionAPI.IsRetail and 'SUPER_TRACKING_CHANGED',
 }) do if event then
 		frame:RegisterEvent(event)

--- a/Logic/Events.lua
+++ b/Logic/Events.lua
@@ -8,6 +8,7 @@ function NPC:GOSSIP_SHOW(customGossipHandler)
 end
 
 function NPC:PLAYER_INTERACTION_MANAGER_FRAME_HIDE(...)
+	API:CloseGossip(true, ...)
 	self:PlayOutro()
 	L.ClickedTitleCache = nil
 end

--- a/Logic/Events.lua
+++ b/Logic/Events.lua
@@ -7,6 +7,11 @@ function NPC:GOSSIP_SHOW(customGossipHandler)
 	self:HandleGossipOpenEvent(customGossipHandler)
 end
 
+function NPC:PLAYER_INTERACTION_MANAGER_FRAME_HIDE(...)
+	self:PlayOutro()
+	L.ClickedTitleCache = nil
+end
+
 function NPC:GOSSIP_CLOSED(...)
 	API:CloseGossip(true, ...)
 	self:PlayOutro()


### PR DESCRIPTION
Currently if have immersion chat open from an npc like vendor with multiple choices or flight vendor it doesn't close this will make sure it closes.