### PR TITLE
Add camera rotation option if ui is hidden

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -76,6 +76,8 @@ L.defaults = {
 	boxlock = true,
 	boxpoint = 'Bottom',
 
+	camerarotationenabled = false,
+
 	disableprogression = false,
 	flipshortcuts = false,
 	delaydivisor = 15,
@@ -258,6 +260,16 @@ L.options = {
 							get = L.GetFromSV,
 							set = function(_, val)
 								L.cfg.hidetooltip = val
+							end,
+						},
+						camerarotationenabled = {
+							type = 'toggle',
+							name = L['Rotate camera'],
+							disabled = function() return not L('hideui') end,
+							order = 1,
+							get = L.GetFromSV,
+							set = function(_, val)
+								L.cfg.camerarotationenabled = val
 							end,
 						},
 					},

--- a/Display/Fademgr.lua
+++ b/Display/Fademgr.lua
@@ -131,6 +131,10 @@ function frame:FadeIn(fadeTime, playAnimations, ignoreFrameFade)
 
 		self.ignoredFadeFrames = framesToIgnore
 	end
+
+	if L('hideui') and L('camerarotationenabled') then 
+		MoveViewRightStart(0.1)
+	end
 end
 
 function frame:FadeOut(fadeTime, ignoreOnTheFly)
@@ -142,6 +146,9 @@ function frame:FadeOut(fadeTime, ignoreOnTheFly)
 		self.fadeState = 'out'
 	end
 	RestoreFadedFrames(self)
+	if L('hideui') and L('camerarotationenabled') then 
+		MoveViewRightStop(0)
+	end
 end
 
 ----------------------------------

--- a/Display/Fademgr.lua
+++ b/Display/Fademgr.lua
@@ -133,7 +133,7 @@ function frame:FadeIn(fadeTime, playAnimations, ignoreFrameFade)
 	end
 
 	if L('hideui') and L('camerarotationenabled') then 
-		MoveViewRightStart(0.1)
+		MoveViewRightStart(0.02)
 	end
 end
 
@@ -147,7 +147,7 @@ function frame:FadeOut(fadeTime, ignoreOnTheFly)
 	end
 	RestoreFadedFrames(self)
 	if L('hideui') and L('camerarotationenabled') then 
-		MoveViewRightStop(0)
+		MoveViewRightStop()
 	end
 end
 

--- a/Locale/deDE.lua
+++ b/Locale/deDE.lua
@@ -41,3 +41,4 @@ L["The quest/gossip text doesn't vanish when you stop interacting with the NPC o
 L["The regular talking head frame appears in the same place as Immersion when you're not interacting with anything and on top of Immersion if they are visible at the same time."] = "Der normale sprechende Kopf erscheint an der gleichen Stelle wie Immersion, beziehungsweise überdeckt Immersion, wenn man mit nichts interagiert und beide zur gleichen Zeit sichtbar sind."
 L["Tooltip"] = "Tooltip"
 L["Use your primary mouse button to read through text, accept/turn in quests and select the best available gossip option."] = "Benutze deine primäre Maustaste um Texte durchzulesen, Quests zu akzeptieren und die beste Gesprächsoption auszuwählen."
+L["Rotate camera"] = "Rotiere Kamera"

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -43,3 +43,4 @@ L["The regular talking head frame appears in the same place as Immersion when yo
 L["Tooltip"] = "Tooltip"
 L["Use your primary mouse button to read through text, accept/turn in quests and select the best available gossip option."] = "Use your primary mouse button to read through text, accept/turn in quests and select the best available gossip option."
 L["When a quest is supertracked (clicked on in the objective tracker, or set automatically by proximity), the quest text will play if nothing else is obstructing it."] = "When a quest is supertracked (clicked on in the objective tracker, or set automatically by proximity), the quest text will play if nothing else is obstructing it."
+L["Rotate camera"] = "Rotate camera"


### PR DESCRIPTION
Add the option to rotate the camera if ui is hidden.
This will lead to a more dynamic experience.
