### PR TITLE
Add gossip text sort option

### DIFF
--- a/Components/Titles.lua
+++ b/Components/Titles.lua
@@ -230,6 +230,9 @@ function Titles:UpdateActiveQuests(data)
 end
 
 function Titles:UpdateGossipOptions(data)
+	if L('gossipsort') == 'BLIZZARD' then
+		table.sort(data, GossipOptionSort)
+	end
 	for i, option in ipairs(data) do
 		local button = self:GetButton(self.idx)
 		----------------------------------

--- a/Config.lua
+++ b/Config.lua
@@ -84,6 +84,8 @@ L.defaults = {
 	inspect = 'SHIFT',
 	accept = 'SPACE',
 	reset = 'BACKSPACE',
+
+	gossipsort = 'NONE'
 }---------------------------------
 
 local stratas = {
@@ -115,6 +117,11 @@ local titleanis = {
 	[1]  = SPELL_CAST_TIME_INSTANT,
 	[5]  = FAST,
 	[10] = SLOW,
+}
+
+local gossipsortoptions = {
+	NONE = L['None'],
+	BLIZZARD = 'Blizzard'
 }
 
 L.options = {
@@ -531,6 +538,17 @@ L.options = {
 								L.cfg.titlescale = val
 								L.frame.TitleButtons:SetScale(val)
 							end,
+						},
+						gossipsort = {
+							type = 'select',
+							name = L['Sort gossip options'],
+							order = 2,
+							values = gossipsortoptions,
+							get = L.GetFromDefaultOrSV,
+							set = function(_, val)
+								L.cfg.gossipsort = val
+							end,
+							style = 'dropdown',
 						},
 					},
 				},

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -43,3 +43,5 @@ L["The regular talking head frame appears in the same place as Immersion when yo
 L["Tooltip"] = "Tooltip"
 L["Use your primary mouse button to read through text, accept/turn in quests and select the best available gossip option."] = "Use your primary mouse button to read through text, accept/turn in quests and select the best available gossip option."
 L["When a quest is supertracked (clicked on in the objective tracker, or set automatically by proximity), the quest text will play if nothing else is obstructing it."] = "When a quest is supertracked (clicked on in the objective tracker, or set automatically by proximity), the quest text will play if nothing else is obstructing it."
+L["Sort gossip options"] = "Sort gossip options"
+L["None"] = "None"

--- a/Locale/frFR.lua
+++ b/Locale/frFR.lua
@@ -35,3 +35,5 @@ L["Text speed"] = [=[Vitesse du texte]=]
 L["The quest/gossip text doesn't vanish when you stop interacting with the NPC or when accepting a new quest. Instead, it vanishes at the end of the text sequence. This allows you to maintain your immersive experience when speed leveling."] = [=[Le texte de quête/discussion ne disparaît pas lorsque vous arrêtez d'interagir avec le PNJ ou lorsque vous acceptez une nouvelle quête. Au lieu de cela, il disparaît à la fin de la séquence du texte. Ce qui vous permet de maintenir votre expérience immersive lors de la montée de niveaux rapide.]=]
 L["Tooltip"] = [=[Info-bulle]=]
 L["Use your primary mouse button to read through text, accept/turn in quests and select the best available gossip option."] = [=[Utilisez votre bouton de souris primaire pour parcourir le texte, accepter/rendre des quêtes et choisir la meilleure option de discussion disponible.]=]
+L["Sort gossip options"] = "Tri des textes de discussion"
+L["None"] = "Aucun"


### PR DESCRIPTION
Hi,
Gossip options are not sorted like in the default Blizzard UI.
It's quite annoying when you're doing a dungeon like Azure Vault, wipe then having to use the portals. Your group tells you to use the last gossip option to get to the correct place but the last option on their screen (without immersion) is not the same as yours (with immersion).

This PR adds an option to set a gossip sort to either None (immersion's current behavior and this PR's default value) or Blizzard (using `GossipOptionSort` function which uses the `orderIndex` value of the gossip info).

I chose a select option in case you want to add other sorting options later.