### PR TITLE
Add combat lockdown conditional check for SetPropagateKeyboardInput(), fixes issue #32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Libs/
 .release
+.idea/

--- a/Logic/Frame.lua
+++ b/Logic/Frame.lua
@@ -408,10 +408,14 @@ function Frame:OnKeyDown(button)
 		self:ForceClose()
 		return
 	elseif self:ParseControllerCommand(button) then
-		self:SetPropagateKeyboardInput(false)
+		if not InCombatLockdown() then
+			self:SetPropagateKeyboardInput(false)
+		end
 		return
 	elseif self:IsInspectModifier(button) and self.hasItems then
-		self:SetPropagateKeyboardInput(false)
+		if not InCombatLockdown() then
+			self:SetPropagateKeyboardInput(false)
+		end
 		self:ShowItems()
 		return
 	end
@@ -425,12 +429,18 @@ function Frame:OnKeyDown(button)
 	end
 	if input then
 		input(self)
-		self:SetPropagateKeyboardInput(false)
+		if not InCombatLockdown() then
+			self:SetPropagateKeyboardInput(false)
+		end
 	elseif L.cfg.enablenumbers and tonumber(button) then
 		inputs.number(self, tonumber(button))
-		self:SetPropagateKeyboardInput(false)
+		if not InCombatLockdown() then
+			self:SetPropagateKeyboardInput(false)
+		end
 	else
-		self:SetPropagateKeyboardInput(true)
+		if not InCombatLockdown() then
+			self:SetPropagateKeyboardInput(true)
+		end
 	end
 end
 


### PR DESCRIPTION
[In 10.1.5](https://warcraft.wiki.gg/wiki/Patch_10.1.5/API_changes) Blizzard made [frame:SetPropagateKeyboardInput()](https://warcraft.wiki.gg/wiki/API_Frame_SetPropagateKeyboardInput) a restricted function that is no longer able to be called in combat from insecure code. To work around this limitation, this patch wraps the calls to this function with an InCombatLockdown() conditional check.

This patch fixes issue #32, and from my testing does not break anything that I have noticed.

