### PR TITLE
TTS delay; new time calc.; bug fixes for instances

### DIFF
--- a/Components/Text.lua
+++ b/Components/Text.lua
@@ -8,9 +8,8 @@ do  local LINE_FEED, CARRIAGE_RETURN = string.char(10), string.char(13)
 	LINE_BREAK_REPLACE = LINE_FEED .. CARRIAGE_RETURN .. LINE_FEED
 end
 
-local TEXT_TIME_DIVISOR -- set later as baseline divisor for (text length / time).
-local TEXT_TIME_PADDING = 2 -- static padding, feels more natural with a pause to breathe.
-local MAX_UNTIL_SPLIT = 200 -- start recursive string splitting if the text is too long.
+   local TEXT_TIME_DIVISOR       -- set later as baseline divisor for (text length / time).
+   local MAX_UNTIL_SPLIT   = 200 -- start recursive string splitting if the text is too long.
 
 Timer.Texts = {}
 L.TextMixin = {}
@@ -56,8 +55,28 @@ function Text:CreateLineData(text)
 	return timeToFinish, strings, timers
 end
 
-function Text:CalculateLineTime(length)
-	return (length / (TEXT_TIME_DIVISOR or 15) ) + TEXT_TIME_PADDING
+function Text:CalculateLineTime(length, nEndPunct, nMidPunct)
+	-- Calcuate time to allow for reading text (and for TTS if enabled).
+	-- For matching TTS, the linear calculation (constant divisor) sometimes resulted in too little time for short phrases (TTS clipped)
+	-- and too much time for long phrases (seconds of dead air).  This now scales by an inverse logarithm of the phrase length,
+	-- so more time is given for short phrases and relatively less time for longer phrases.
+	-- The Text speed option, TEXT_TIME_DIVISOR, is still applied by changing the base of the logarithm to the TEXT_TIME_DIVISORth root of 30.
+	-- It is calibrated for a phrase that is 30 characters long with a TEXT_TIME_DIVISOR = 15 to yield a time of 2 seconds.
+
+	-- It also gives extra time if the phrase has a lot of punctuation, because TTS will typically pause briefly for each:
+	--     half a second for each sentence-ending punctuation: period, exclamation point, or question mark
+	--     quarter of a second for each mid-sentence punctuation: comma, colon, semi-colon.
+
+	-- Protect against a length of 0, which causes math.log to fail, or 1, which causes math.log to return 0 and the division to fail
+	local safeLength = math.max(2, length)
+
+	-- If arguments are missing or nil, default them to 0
+	nEndPunct = nEndPunct or 0
+	nMidPunct = nMidPunct or 0
+
+	-- Changed formula to give more time for shorter strings, which were getting clipped, and less time for longer strings, which often had seconds of dead air after them.
+	-- return (safeLength /                                        (TEXT_TIME_DIVISOR or 15)   )                                          +   TEXT_TIME_PADDING
+	   return (safeLength / (math.log(safeLength) / math.log(30^(1/(TEXT_TIME_DIVISOR or 15))))) + (0.5 * nEndPunct) + (0.25 * nMidPunct) + L.TEXT_TIME_PADDING
 end
 
 function Text:AddString(str, strings, timers)
@@ -75,7 +94,42 @@ function Text:AddString(str, strings, timers)
 		end
 	end
 	if ( length ~= 0 or forceShow ) then
-		timer = self:CalculateLineTime(length)
+		-- Clean up the verbatim phrase for a more accurate reading calculation of TTS time
+		-- Count punctuation so extra time can be allowed for TTS if there are a lot of short sentences vs one long, flowing sentence.
+ 		local cleanStr = str or ""
+
+ 		-- For debugging, print the original text to chat before processing
+		-- print("|cff00ff00[Immersion Before]:|r " .. tostring(cleanStr))
+
+		-- 1. Clean the string.
+			-- a. Normalize the 3-byte ellipsis character to a standard period
+			cleanStr = string.gsub(cleanStr, "…", ".")
+
+			-- b. Remove all spaces that sit directly between ending punctuation
+			local changed
+			repeat
+				cleanStr, changed = string.gsub(cleanStr, "([.!?])%s+([.!?])", "%1%2")
+			until changed == 0
+
+			-- c. Collapse any remaining sequence of 2 or more ending punctuation into just one
+			cleanStr = string.gsub(cleanStr, "([.!?])[.!?]+", "%1")
+
+			-- d. Strip ALL leading punctuation, symbols, and spaces: many phrases begin with ...
+			cleanStr = string.gsub(cleanStr, "^[%p%s]+", "")
+
+		-- 2. Count major sentence-ending punctuation (. ? !)
+		local _, nEndPunct = string.gsub(cleanStr, "[.?!]", "")
+
+		-- 3. Count minor pauses (, ; :)
+		local _, nMidPunct = string.gsub(cleanStr, "[,;:]", "")
+
+		-- For debuggin, print the cleaned text to chat after processing
+		-- print("|cffff0000[Immersion After]:|r " .. tostring(cleanStr))
+
+		-- Recount the length of the (cleaned) string.
+		local length2 = strlenutf8(cleanStr) or 0
+
+		timer = self:CalculateLineTime(length, nEndPunct, nMidPunct)
 		timers[ #strings + 1] = timer
 		strings[ #strings + 1 ] = str
 	end
@@ -175,6 +229,18 @@ function Text:DisplayLine(text, time)
 	self:SetCurrentLineTime(time)
 	self:ApplyFontObjects()
 
+	-- Since TTS has a 3-second delay on the first phrase of the interaction, the time to display the text must be increased
+	-- If this is the first displayed phrase of the interaction with the unit and TTS is enabled,
+	-- add an extra 3 seconds to the line's timer so TTS has time to finish.
+	if L.___ttsDelayedStart and L('ttsenabled') then
+		-- add to remaining timer for the current line
+		if self.timers and self.timers[1] then
+			self.timers[1] = self.timers[1] + 3
+		end
+		-- also add to the original/current line time so progress calculations remain correct
+		self.currentLineTime = (self.currentLineTime or 0) + 3
+	end
+
 	if self.OnDisplayLineCallback then
 		self:OnDisplayLineCallback(text, time)
 	end
@@ -187,12 +253,26 @@ function Text:SetFontObjectsToTry(...)
 	end
 end
 
+-- Cache global security/sandboxing functions locally
+local issecretvalue  = issecretvalue
+local canaccessvalue = canaccessvalue
+
 function Text:ApplyFontObjects()
 	self:CheckApplicableFonts()
 
 	for i, fontObject in ipairs(self.fontObjectsToTry) do
 		self:SetFontObject(fontObject)
-		if not self:IsTruncated() then
+
+		-- Get truncation state
+		local truncated = self:IsTruncated()
+
+		-- If Blizzard returned a secret boolean, we cannot safely test it
+		if issecretvalue and issecretvalue(truncated) and (not canaccessvalue or not canaccessvalue(truncated)) then
+			-- Stop here; don't boolean-test a secret value
+			break
+		end
+		-- Safe to test normally
+		if not truncated then
 			break
 		end
 	end
@@ -264,7 +344,9 @@ function Timer:AddText(fontString)
 	end
 end
 
-function Timer:GetTexts() return pairs(self.Texts) end
+function Timer:GetTexts()
+	return pairs(self.Texts)
+end
 
 function Timer:RemoveText(fontString)
 	if fontString then

--- a/Config.lua
+++ b/Config.lua
@@ -1,5 +1,7 @@
 local _, L = ...
 
+L.TEXT_TIME_PADDING = 0.5 -- static padding, feels more natural with a pause to breathe.  Moved from Text.lua so that it can be used in the calculations for the mouseover description of Text speed option
+
 function L.GetListString(...)
 	local ret = ''
 	local strings = {...}
@@ -163,14 +165,17 @@ L.options = {
 						delaydivisor = {
 							type = 'range',
 							name = 'Text speed',
+							-- formulas below match formula in Text.lua for TTS time TTS calculations
 							desc = L['Change the speed of text delivery.'] .. '\n\n' ..
-								MINIMUM .. '\n"' ..  L['How are you doing today?'] .. '"\n  -> ' .. 
-								format(D_SECONDS, (strlen(L['How are you doing today?']) / 5) + 2)  .. '\n\n' .. 
-								MAXIMUM .. '\n"' .. L['How are you doing today?'] .. '"\n  -> ' .. 
-								format(D_SECONDS, (strlen(L['How are you doing today?']) / 40) + 2),
+								MINIMUM .. " = 5" .. '\n"' ..  'I need help with these quests.' .. '"\n  -> ' .. 
+								format(string.gsub(D_SECONDS, "%%[ds]", "%%.2f"), (strlen('I need help with these quests.') / (math.log(strlen('I need help with these quests.')) / math.log(30^(1/ 5)))) + L.TEXT_TIME_PADDING)  .. '\n\n' .. 
+								"Default = 15" .. '\n"' ..  'I need help with these quests.' .. '"\n  -> ' .. 
+								format(string.gsub(D_SECONDS, "%%[ds]", "%%.2f"), (strlen('I need help with these quests.') / (math.log(strlen('I need help with these quests.')) / math.log(30^(1/15)))) + L.TEXT_TIME_PADDING)  .. '\n\n' .. 
+								MAXIMUM .. " = 40" .. '\n"' .. 'I need help with these quests.' .. '"\n  -> ' .. 
+								format(string.gsub(D_SECONDS, "%%[ds]", "%%.2f"), (strlen('I need help with these quests.') / (math.log(strlen('I need help with these quests.')) / math.log(30^(1/40)))) + L.TEXT_TIME_PADDING),
 							min = 5,
 							max = 40,
-							step = 5,
+							step = 1,  -- changed 5 to 1 for more sensitivity when trying to match the text visual display time with the TTS time
 							order = 1,
 							get = L.GetFromDefaultOrSV,
 							set = function(self, val) 

--- a/Display/Onload.lua
+++ b/Display/Onload.lua
@@ -5,6 +5,7 @@ local titles = frame.TitleButtons
 local inspector = frame.Inspector
 local elements = talkbox.Elements
 L.frame = frame
+L.___ttsDelayedStart = true  -- flag for delaying TTS when first interacting with a unit (to give them time to say their Blizzard-recorded snippet)
 
 ----------------------------------
 -- Prepare propagation, so that we
@@ -250,13 +251,23 @@ function text:OnDisplayLineCallback(text)
 
 		if ( text and L('ttsenabled') ) then
 			C_VoiceChat.StopSpeakingText()
-			C_Timer.After(0, function()
+
+			-- If text is flagged for TTS delay (i.e., first phrase), wait 3 seconds to allow time for the unit to speak its Blizzard-recorded snippet that occurs when clicking on it
+			local delay = L.___ttsDelayedStart and 3 or 0
+
+			C_Timer.After(delay, function()
 				C_VoiceChat.SpeakText(
 					(model:GetVoice() or 1) -1,
 					text,
 					L('ttsrate'),
-					L('ttsvolume'))
+					L('ttsvolume')
+				) 
 			end)
+
+			-- After the delay is applied to the first TTS phrase, set the flag to false so that the remaining phrases will play without delay
+			if delay == 3 then
+				L.___ttsDelayedStart = false
+			end
 		end
 	end
 end
@@ -276,6 +287,9 @@ talkbox:RegisterForDrag('LeftButton')
 talkbox.TextFrame.SpeechProgress:SetFont('Fonts\\MORPHEUS.ttf', 16, '')
 talkbox.TextFrame.SpeechProgress:SetShadowColor(0, 0, 0, 1)
 talkbox.TextFrame.SpeechProgress:SetShadowOffset(0, -1)
+
+-- rearm the TTS delay at the start of each interaction
+talkbox:HookScript('OnShow', function() L.___ttsDelayedStart = true end)
 
 ----------------------------------
 -- Set movable frames

--- a/Interface.lua
+++ b/Interface.lua
@@ -345,9 +345,28 @@ function API:GetNamePlateForUnit(...)
 end
 
 function API:GetCreatureID(unit)
+	-- If the unit exists, fetch the Globally Unique Identifier (GUID).
 	local guid = unit and UnitGUID(unit)
-	return guid and select(6, strsplit('-', guid))
+
+	-- Check if Blizzard is hiding the unit ID so that the text display will initiate.
+	-- If hidden, the portrait of the unit speaking will be blank.
+
+	-- Validate that the retrieved GUID is a valid string
+	if not guid or type(guid) ~= "string" then return nil end
+	-- Filter out restricted or classified GUIDs that would cause a crash
+	if issecretvalue and issecretvalue(guid) then return nil end
+
+	-- Parse the GUID using a protected call (pcall).
+	-- WoW GUIDs use a hyphen-separated format (e.g., "Creature-0-1234-567-890-12345-0000000000").
+	-- The 6th token in a standard Creature GUID represents the specific Creature ID.
+	local ok, creatureID = pcall(function()
+		return select(6, strsplit('-', guid))
+	end)
+
+	-- If the pcall succeeded, return the extracted ID; otherwise, return nil.
+	return ok and creatureID or nil
 end
+
 
 function API:CloseItemText(...)
 	if CloseItemText then return CloseItemText(...) end


### PR DESCRIPTION
When TTS is enabled, added a 3-second delay to the first phrase of the interaction.  This allows WoW to play the Blizzard-recorded snippet that many units speak when they are clicked on or interacted with.  It only affects the very first phrase of the interaction.  It does not repeat the delay if the text is rewound to the beginning while within the same interaction (backspace key).  If the interaction is ended/closed, the delay will repeat once interacting with again.

The calculation for how much time to display each phrase of text has been changed from linear scaling to logarithmic.  With TTS enabled, this allows more time for short phrases that may get clipped otherwise, and it shortens the time for very long phrases that may have several seconds of dead air at the end.  The calculation is calibrated so that a phrase of 30 characters is displayed for 2 seconds when the Text Speed option is set to the default 15.  The time is also padded for punctuation (0.5 seconds for the ends of sentences, and 0.25 seconds for pauses mid-sentence) to allow for similar pauses in TTS.

Two bugs were fixed when interacting with a unit inside an instance.  Blizzard has protected/hidden some unit variables while inside instances.  These fixes allow the addon to continue without crashing.  However, it does result in a blank portrait in the display (because the unit GUID is hidden).